### PR TITLE
Update examples to use with_methods to create ctor

### DIFF
--- a/6_object_wrap/abi/myobject.cc
+++ b/6_object_wrap/abi/myobject.cc
@@ -13,26 +13,14 @@ void MyObject::Destructor(void* nativeObject) {
 }
 
 void MyObject::Init(napi_env env, napi_value exports) {
-  napi_value function = napi_create_constructor_for_wrap(env, New);
-  napi_set_function_name(env, function, napi_property_name(env, "MyObject"));
-  napi_value prototype =
-    napi_get_property(env, function, napi_property_name(env, "prototype"));
+  napi_method_descriptor methods[] = {
+    { GetValue, "napi_value" },
+    { PlusOne, "plusOne" },
+    { Multiply, "multiply" },
+  };
 
-  napi_value napi_valueFunction = napi_create_function(env, GetValue);
-  napi_set_function_name(env, napi_valueFunction, napi_property_name(env, "napi_value"));
-  napi_set_property(env, prototype, napi_property_name(env, "napi_value"),
-                        napi_valueFunction);
-
-  napi_value plusOneFunction = napi_create_function(env, PlusOne);
-  napi_set_function_name(env, plusOneFunction, napi_property_name(env, "plusOne"));
-  napi_set_property(env, prototype, napi_property_name(env, "plusOne"),
-                        plusOneFunction);
-
-
-  napi_value multiplyFunction = napi_create_function(env, Multiply);
-  napi_set_function_name(env, multiplyFunction, napi_property_name(env, "multiply"));
-  napi_set_property(env, prototype, napi_property_name(env, "multiply"), 
-                        multiplyFunction);
+  napi_value function = napi_create_constructor_for_wrap_with_methods(
+          env, New, "MyObject", 3, methods);
 
   constructor = napi_create_persistent(env, function);
 

--- a/7_factory_wrap/abi/myobject.cc
+++ b/7_factory_wrap/abi/myobject.cc
@@ -12,15 +12,11 @@ void MyObject::Destructor(void* nativeObject) {
 napi_persistent MyObject::constructor;
 
 void MyObject::Init(napi_env env) {
-  napi_value function = napi_create_constructor_for_wrap(env, New);
-  napi_set_function_name(env, function, napi_property_name(env, "MyObject"));
-  napi_value prototype =
-    napi_get_property(env, function, napi_property_name(env, "prototype"));
+  napi_method_descriptor methods[] = {
+    { PlusOne, "plusOne" },
+  };
 
-  napi_value plusOneFunction = napi_create_function(env, PlusOne);
-  napi_set_function_name(env, plusOneFunction, napi_property_name(env, "plusOne"));
-  napi_set_property(env, prototype, napi_property_name(env, "plusOne"),
-                        plusOneFunction);
+  napi_value function = napi_create_constructor_for_wrap_with_methods(env, New, "MyObject", 1, methods);
 
   constructor = napi_create_persistent(env, function);
 }


### PR DESCRIPTION
Use napi_create_constructor_for_wrap_with_methods to create constructor
function objects that have methods hooked up on their .prototype object.

This should be the way to create a constructor function object with
methods for performance reasons on V8.  The previous method is slow and
thus misleading to have as the example code for how to write a native
addon with NAPI.