### PR TITLE
Emit event from cpp with libuv and napi

### DIFF
--- a/emit_event_from_cpp/napi/binding.gyp
+++ b/emit_event_from_cpp/napi/binding.gyp
@@ -1,0 +1,30 @@
+{
+  "targets": [
+    {
+      "target_name": "emit_from_cpp",
+      "sources": [
+        "src/emit-from-cpp.cc"
+      ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
+      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+      'conditions': [
+        ['OS=="win"', {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "ExceptionHandling": 1
+            }
+          }
+        }],
+        ['OS=="mac"', {
+          "xcode_settings": {
+            "CLANG_CXX_LIBRARY": "libc++",
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7'
+          }
+        }]
+      ]
+    }
+  ]
+}

--- a/emit_event_from_cpp/napi/binding.gyp
+++ b/emit_event_from_cpp/napi/binding.gyp
@@ -3,7 +3,8 @@
     {
       "target_name": "emit_from_cpp",
       "sources": [
-        "src/emit-from-cpp.cc"
+        "src/emit-from-cpp.cc",
+        "src/napi_itc_queue.cc"
       ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],

--- a/emit_event_from_cpp/napi/binding.gyp
+++ b/emit_event_from_cpp/napi/binding.gyp
@@ -7,8 +7,6 @@
       ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
-      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'conditions': [
         ['OS=="win"', {
           "msvs_settings": {

--- a/emit_event_from_cpp/napi/index.js
+++ b/emit_event_from_cpp/napi/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const EventEmitter = require('events').EventEmitter
+const addon = require('bindings')('emit_from_cpp')
+
+const emitter = new EventEmitter()
+
+emitter.on('start', () => {
+    console.log('### START ...')
+})
+emitter.on('data', (evt) => {
+    console.log(evt);
+})
+
+emitter.on('end', () => {
+    console.log('### END ###')
+})
+
+addon.callEmit(emitter.emit.bind(emitter))

--- a/emit_event_from_cpp/napi/index.js
+++ b/emit_event_from_cpp/napi/index.js
@@ -5,18 +5,16 @@ const addon = require("bindings")("emit_from_cpp");
 
 const emitter = new EventEmitter();
 
-emitter.on("start", () => {
-  console.log("### START ...");
+emitter.on("start", name => {
+  console.log("### START ...", name);
 });
 emitter.on("data", evt => {
   console.log("event from addon >>", evt);
 });
 
-emitter.on("end", () => {
-  console.log("### END ###");
+emitter.on("end", name => {
+  console.log("### END ###", name);
 });
 
-setTimeout(() => {
-  addon.callEmit(emitter.emit.bind(emitter));
-}, 3000);
-addon.callEmit(emitter.emit.bind(emitter));
+addon.callEmit("producer1", emitter.emit.bind(emitter));
+addon.callEmit("producer2", emitter.emit.bind(emitter));

--- a/emit_event_from_cpp/napi/index.js
+++ b/emit_event_from_cpp/napi/index.js
@@ -4,7 +4,6 @@ const EventEmitter = require("events").EventEmitter;
 const addon = require("bindings")("emit_from_cpp");
 
 const emitter = new EventEmitter();
-let handle;
 
 emitter.on("start", () => {
   console.log("### START ...");
@@ -15,8 +14,9 @@ emitter.on("data", evt => {
 
 emitter.on("end", () => {
   console.log("### END ###");
-  clearInterval(handle);
 });
 
+setTimeout(() => {
+  addon.callEmit(emitter.emit.bind(emitter));
+}, 3000);
 addon.callEmit(emitter.emit.bind(emitter));
-handle = setInterval(() => console.log("interval in JS"), 1000);

--- a/emit_event_from_cpp/napi/index.js
+++ b/emit_event_from_cpp/napi/index.js
@@ -1,19 +1,22 @@
-'use strict'
+"use strict";
 
-const EventEmitter = require('events').EventEmitter
-const addon = require('bindings')('emit_from_cpp')
+const EventEmitter = require("events").EventEmitter;
+const addon = require("bindings")("emit_from_cpp");
 
-const emitter = new EventEmitter()
+const emitter = new EventEmitter();
+let handle;
 
-emitter.on('start', () => {
-    console.log('### START ...')
-})
-emitter.on('data', (evt) => {
-    console.log(evt);
-})
+emitter.on("start", () => {
+  console.log("### START ...");
+});
+emitter.on("data", evt => {
+  console.log("event from addon >>", evt);
+});
 
-emitter.on('end', () => {
-    console.log('### END ###')
-})
+emitter.on("end", () => {
+  console.log("### END ###");
+  clearInterval(handle);
+});
 
-addon.callEmit(emitter.emit.bind(emitter))
+addon.callEmit(emitter.emit.bind(emitter));
+handle = setInterval(() => console.log("interval in JS"), 1000);

--- a/emit_event_from_cpp/napi/package.json
+++ b/emit_event_from_cpp/napi/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "emit-event-from-cpp-example",
+  "version": "0.0.0",
+  "description": "Node.js Addons - emit event from C++ to JS",
+  "main": "index.js",
+  "private": true,
+  "gypfile": true,
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "node-addon-api": "*",
+    "bindings": "*"
+  }
+}

--- a/emit_event_from_cpp/napi/package.json
+++ b/emit_event_from_cpp/napi/package.json
@@ -9,7 +9,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "node-addon-api": "*",
     "bindings": "*"
   }
 }

--- a/emit_event_from_cpp/napi/src/emit-from-cpp.cc
+++ b/emit_event_from_cpp/napi/src/emit-from-cpp.cc
@@ -1,0 +1,27 @@
+#include<napi.h>
+
+#include <chrono>
+#include <thread>
+#include <iostream>
+
+Napi::Value CallEmit(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::Function emit = info[0].As<Napi::Function>();
+    emit.Call({Napi::String::New(env, "start")});
+    for(int i = 0; i < 3; i++) {
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+        emit.Call({Napi::String::New(env, "data"),
+            Napi::String::New(env, "data ...")});
+    }
+    emit.Call({Napi::String::New(env, "end")});
+    return Napi::String::New(env, "OK");
+}
+
+// Init
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set(Napi::String::New(env, "callEmit"),
+        Napi::Function::New(env, CallEmit));
+    return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init);

--- a/emit_event_from_cpp/napi/src/emit-from-cpp.cc
+++ b/emit_event_from_cpp/napi/src/emit-from-cpp.cc
@@ -1,6 +1,3 @@
-#include <node_api.h>
-#include <uv.h>
-
 #include <chrono>
 #include <thread>
 #include <iostream>
@@ -95,7 +92,7 @@ static napi_value CallEmit(napi_env env, napi_callback_info info) {
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value callEmit;
   NAPI_CALL(env, napi_create_function(env, "", 0, CallEmit, nullptr, &callEmit));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "callEmit", callEmit))
+  NAPI_CALL(env, napi_set_named_property(env, exports, "callEmit", callEmit));
   return exports;
 }
 

--- a/emit_event_from_cpp/napi/src/emit-from-cpp.cc
+++ b/emit_event_from_cpp/napi/src/emit-from-cpp.cc
@@ -1,27 +1,118 @@
-#include<napi.h>
+#include <node_api.h>
+#include <uv.h>
 
 #include <chrono>
 #include <thread>
 #include <iostream>
+#include <assert.h>
 
-Napi::Value CallEmit(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    Napi::Function emit = info[0].As<Napi::Function>();
-    emit.Call({Napi::String::New(env, "start")});
-    for(int i = 0; i < 3; i++) {
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-        emit.Call({Napi::String::New(env, "data"),
-            Napi::String::New(env, "data ...")});
-    }
-    emit.Call({Napi::String::New(env, "end")});
-    return Napi::String::New(env, "OK");
+// Helper
+#define NAPI_CALL(env, call)                                                   \
+  {                                                                            \
+    napi_status status = call;                                                 \
+    assert(status == napi_ok);                                                 \
+  }
+
+using namespace std;
+static uv_sem_t semaphore;
+static uv_async_t uv_async;
+static napi_env cached_env = nullptr; // !!use only within the uvCallback!!
+static napi_ref func_ref;
+static bool stop = false;
+static int iteration;
+
+static void uvFinalize(uv_handle_t* handle) {
+  cout << "Finalize";
 }
 
-// Init
-Napi::Object Init(Napi::Env env, Napi::Object exports) {
-    exports.Set(Napi::String::New(env, "callEmit"),
-        Napi::Function::New(env, CallEmit));
-    return exports;
+static void uvCallback(uv_async_t* handle) {
+  // cout << "in uv loop\n";
+  iteration++;
+
+  napi_env env = cached_env;
+  napi_async_context async_context;
+  napi_handle_scope scope;
+  napi_callback_scope callback_scope;
+  napi_value argv[2], global, func, resource_name, resource_object;
+
+  /* setup for the callback */
+  NAPI_CALL(env, napi_open_handle_scope(env, &scope)); // create a new scope in this callback
+  NAPI_CALL(env, napi_create_object(env, &resource_object));
+  NAPI_CALL(env, napi_create_string_utf8(env, "resource_name", NAPI_AUTO_LENGTH, &resource_name));
+  NAPI_CALL(env, napi_async_init(env, resource_object, resource_name, &async_context));
+  NAPI_CALL(env, napi_open_callback_scope(env, resource_object, async_context, &callback_scope));
+  /*end setup*/
+
+  NAPI_CALL(env, napi_get_global(env, &global));
+  NAPI_CALL(env, napi_get_reference_value(env, func_ref, &func));
+  if (!stop) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "data", NAPI_AUTO_LENGTH, &argv[0]));
+    char buffer[30];
+    snprintf(buffer, sizeof buffer, "data ... %d", iteration);
+    NAPI_CALL(env, napi_create_string_utf8(env, buffer, NAPI_AUTO_LENGTH, &argv[1]));
+    NAPI_CALL(env, napi_make_callback(env, async_context, global, func, 2, argv, nullptr));
+  } else {
+    NAPI_CALL(env, napi_create_string_utf8(env, "end", NAPI_AUTO_LENGTH, &argv[0]));
+    NAPI_CALL(env, napi_make_callback(env, async_context, global, func, 1, argv, nullptr));
+    NAPI_CALL(env, napi_delete_reference(env, func_ref));
+    uv_close((uv_handle_t*)(&uv_async), uvFinalize);
+  }
+
+  /* tear down*/
+  NAPI_CALL(env, napi_close_callback_scope(env, callback_scope));
+  NAPI_CALL(env, napi_async_destroy(env, async_context));
+  NAPI_CALL(env, napi_close_handle_scope(env, scope));
+
+  uv_sem_post(&semaphore); // signal work is done
 }
 
-NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init);
+static void threadRoutine() {
+  for(int i = 0; i < 5; i++) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    uv_async_send(&uv_async);
+    uv_sem_wait(&semaphore);
+    // have to wait for work, because multiple calls to uv_async_send are ignored if the uvCallback is not done being run
+  }
+  stop = true;
+  uv_async_send(&uv_async);
+  uv_sem_wait(&semaphore);
+  uv_sem_destroy(&semaphore);
+}
+
+
+static napi_status initThread(napi_env env) {
+  uv_sem_init(&semaphore, 0);
+  iteration = 0;
+  thread t(threadRoutine);
+  t.detach();
+
+  uv_loop_t* loop;
+  NAPI_CALL(env, napi_get_uv_event_loop(env, &loop));
+  assert(uv_async_init(loop, &uv_async, uvCallback) == 0);
+  cached_env = env;
+  return napi_ok;
+}
+
+
+static napi_value CallEmit(napi_env env, napi_callback_info info) {
+  // this function is not thread safe, be sure to handle your own concurrency, this is just an example
+  size_t argc = 1;
+  napi_value func, event, global;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &func, nullptr, nullptr));
+  NAPI_CALL(env, napi_get_global(env, &global));
+  NAPI_CALL(env, napi_create_string_utf8(env, "start", NAPI_AUTO_LENGTH, &event));
+  NAPI_CALL(env, napi_call_function(env, global, func, 1, &event, nullptr));
+  NAPI_CALL(env, napi_create_reference(env, func, 1, &func_ref));
+
+  NAPI_CALL(env, initThread(env));
+  return nullptr;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_value callEmit;
+  NAPI_CALL(env, napi_create_function(env, "", 0, CallEmit, nullptr, &callEmit));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "callEmit", callEmit))
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.cc
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.cc
@@ -1,0 +1,158 @@
+#include "napi_itc_queue.h"
+#include "utils.h"
+
+static inline void maybe_throw_fatal(napi_env env, napi_status status, int line) {
+  bool is_pending;
+  napi_is_exception_pending(env, &is_pending);
+  if (is_pending || status != napi_ok) {
+    char* loc = new char[200];
+    snprintf(loc, sizeof loc, "file: %s, line: %d\n", __FILE__, line);
+    napi_fatal_error(
+      loc,
+      NAPI_AUTO_LENGTH,
+      "error when setting callback scope",
+      NAPI_AUTO_LENGTH);
+  }
+}
+
+static inline bool maybe_throw_unhandled(napi_env env) {
+  bool is_pending;
+  napi_is_exception_pending(env, &is_pending);
+  if (is_pending) {
+    napi_value fatal;
+    napi_get_and_clear_last_exception(env, &fatal);
+    napi_fatal_exception(env, fatal);
+    return false;
+  }
+  return true;
+}
+
+#define ITC_CALL(env, call)                                                    \
+  maybe_throw_fatal(env, call, __LINE__);
+
+#define NAPI_CALL(call)                                                        \
+  {                                                                            \
+    napi_status status = call;                                                 \
+    if (status != napi_ok) { return status; }                                  \
+  }
+
+#define QUEUE_STOP ((void*)-1)
+
+// static
+struct NapiItcHandle {
+  uv_async_t uv_async;
+  ThreadSafeQueue<void*> consumerQu;
+  napi_itc_consumer_callback execute_cb;
+  napi_itc_complete_callback complete_cb;
+  napi_env env;
+  void* userdata;
+};
+typedef NapiItcHandle napi_itc_handle_t;
+
+static void uvFinalize(uv_handle_t* handle) {
+  auto hdl = (napi_itc_handle_t*)handle;
+  AutoDelete<napi_itc_handle_t> safe_del(hdl);
+
+  if (!hdl->complete_cb) {
+    return;
+  }
+  hdl->complete_cb((napi_itc_handle)hdl, hdl->userdata);
+}
+
+class CallbackScope {
+  public:
+    CallbackScope(napi_env _env): env(_env) {
+      napi_value resource_name, resource_object;
+      ITC_CALL(env, napi_open_handle_scope(env, &scope)); // create a new scope in this callback
+      ITC_CALL(env, napi_create_object(env, &resource_object));
+      ITC_CALL(env, napi_create_string_utf8(env, "itc_uv_resource", NAPI_AUTO_LENGTH, &resource_name));
+      ITC_CALL(env, napi_async_init(env, resource_object, resource_name, &async_context));
+      ITC_CALL(env, napi_open_callback_scope(env, resource_object, async_context, &callback_scope));
+    }
+
+    ~CallbackScope() {
+      ITC_CALL(env, napi_close_callback_scope(env, callback_scope));
+      ITC_CALL(env, napi_async_destroy(env, async_context));
+      ITC_CALL(env, napi_close_handle_scope(env, scope));
+    }
+
+  private:
+    napi_env env;
+    napi_handle_scope scope;
+    napi_callback_scope callback_scope;
+    napi_async_context async_context;
+};
+
+static inline bool uvItcCallback(napi_itc_handle_t* hdl) {
+  if (!hdl->execute_cb) {
+    return false;
+  }
+
+  CallbackScope s(hdl->env);
+  while(!hdl->consumerQu.empty()) {
+    void* eventData;
+    hdl->consumerQu.next(eventData);
+    if (eventData == QUEUE_STOP) {
+      return false;
+    }
+    // should call the user defined callback
+    hdl->execute_cb(hdl->env, (napi_itc_handle)hdl, hdl->userdata, eventData);
+    if (!maybe_throw_unhandled(hdl->env)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void uvCallback(uv_async_t* handle) {
+  auto hdl = (napi_itc_handle_t*)handle;
+  if (!uvItcCallback(hdl)) {
+    uv_close((uv_handle_t*)handle, uvFinalize);
+  }
+}
+
+// extern
+EXTERN_C_START
+
+napi_status napi_itc_init(
+  napi_env env,
+  napi_itc_consumer_callback userExeCallback,
+  napi_itc_complete_callback userCpCallback,
+  void* userdata,
+  napi_itc_handle* handle)
+{
+  napi_value resource_object, resource_name;
+
+  NAPI_CALL(napi_create_object(env, &resource_object));
+  NAPI_CALL(napi_create_string_utf8(env, "napi_itc_init", NAPI_AUTO_LENGTH, &resource_name));
+
+  uv_loop_t* loop;
+  NAPI_CALL(napi_get_uv_event_loop(env, &loop));
+
+  napi_itc_handle_t* hdl = new napi_itc_handle_t;
+  hdl->env = env;
+  hdl->execute_cb = userExeCallback;
+  hdl->complete_cb = userCpCallback;
+  hdl->userdata = userdata;
+
+  if (uv_async_init(loop, &hdl->uv_async, uvCallback)) {
+    delete hdl;
+    return napi_generic_failure;
+  }
+
+  *handle = (napi_itc_handle)hdl;
+  return napi_ok;
+}
+
+void napi_itc_complete(napi_itc_handle handle) {
+  ((napi_itc_handle_t*)handle)->consumerQu.push(QUEUE_STOP);
+  uv_async_send(&((napi_itc_handle_t*)handle)->uv_async);
+}
+
+void napi_itc_send(napi_itc_handle handle, void* data) {
+  // used to queue up events, needs a handle
+  ((napi_itc_handle_t*)handle)->consumerQu.push(data);
+  uv_async_send(&((napi_itc_handle_t*)handle)->uv_async);
+}
+
+EXTERN_C_END

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.cc
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.cc
@@ -1,5 +1,6 @@
 #include "napi_itc_queue.h"
 #include "thread_safe_queue.h"
+#include <uv.h>
 
 static inline void maybe_throw_fatal(napi_env env, napi_status status, int line) {
   bool is_pending;

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.cc
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.cc
@@ -63,7 +63,7 @@ class CallbackScope {
   public:
     CallbackScope(napi_env _env): env(_env) {
       napi_value resource_name, resource_object;
-      ITC_CALL(env, napi_open_handle_scope(env, &scope)); // create a new scope in this callback
+      ITC_CALL(env, napi_open_handle_scope(env, &scope));
       ITC_CALL(env, napi_create_object(env, &resource_object));
       ITC_CALL(env, napi_create_string_utf8(env, "itc_uv_resource", NAPI_AUTO_LENGTH, &resource_name));
       ITC_CALL(env, napi_async_init(env, resource_object, resource_name, &async_context));
@@ -111,7 +111,6 @@ static void uvCallback(uv_async_t* handle) {
   }
 }
 
-// extern
 EXTERN_C_START
 
 napi_status napi_itc_init(
@@ -150,7 +149,6 @@ void napi_itc_complete(napi_itc_handle handle) {
 }
 
 void napi_itc_send(napi_itc_handle handle, void* data) {
-  // used to queue up events, needs a handle
   ((napi_itc_handle_t*)handle)->consumerQu.push(data);
   uv_async_send(&((napi_itc_handle_t*)handle)->uv_async);
 }

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.h
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.h
@@ -2,7 +2,6 @@
 #define __NAPI_ITC_QUEUE_H
 
 #include <node_api.h>
-#include <uv.h>
 
 #ifdef __cplusplus
   #define EXTERN_C_START extern "C" {

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.h
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.h
@@ -1,0 +1,40 @@
+#ifndef __NAPI_ITC_QUEUE_H
+#define __NAPI_ITC_QUEUE_H
+
+#include <node_api.h>
+#include <uv.h>
+
+#ifdef __cplusplus
+  #define EXTERN_C_START extern "C" {
+  #define EXTERN_C_END }
+#else
+  #define EXTERN_C_START
+  #define EXTERN_C_END
+
+  #ifndef true
+    typedef int bool;
+    #define true 1
+    #define false 0
+  #endif
+#endif
+
+EXTERN_C_START
+
+typedef struct napi_itc_handle__ *napi_itc_handle;
+
+typedef void (*napi_itc_consumer_callback) (napi_env, napi_itc_handle, void*, void*);
+typedef void (*napi_itc_complete_callback) (napi_itc_handle, void*);
+
+napi_status napi_itc_init(
+  napi_env env,
+  napi_itc_consumer_callback userExeCallback,
+  napi_itc_complete_callback userCpCallback,
+  void* userdata,
+  napi_itc_handle*);
+
+void napi_itc_send(napi_itc_handle ctx, void* data);
+void napi_itc_complete(napi_itc_handle handle);
+
+EXTERN_C_END
+
+#endif

--- a/emit_event_from_cpp/napi/src/napi_itc_queue.h
+++ b/emit_event_from_cpp/napi/src/napi_itc_queue.h
@@ -20,10 +20,10 @@
 
 EXTERN_C_START
 
-typedef struct napi_itc_handle__ *napi_itc_handle;
+typedef struct napi_itc_handle__ *napi_itc_handle; // opaque pointer a la NAPI
 
 typedef void (*napi_itc_consumer_callback) (napi_env, napi_itc_handle, void*, void*);
-typedef void (*napi_itc_complete_callback) (napi_itc_handle, void*);
+typedef void (*napi_itc_complete_callback) (napi_env, napi_itc_handle, napi_status, void*);
 
 napi_status napi_itc_init(
   napi_env env,

--- a/emit_event_from_cpp/napi/src/thread_safe_queue.h
+++ b/emit_event_from_cpp/napi/src/thread_safe_queue.h
@@ -28,21 +28,6 @@ public:
     qu.pop();
     return true;
   }
-
-  bool empty() {
-    std::unique_lock<std::mutex> lock(m);
-    return qu.empty();
-  }
-};
-
-template <class T>
-class AutoDelete
-{
-  public:
-    AutoDelete (T * p = 0) : ptr_(p) {}
-    ~AutoDelete () throw() { delete ptr_; }
-  private:
-    T *ptr_;
 };
 
 #endif

--- a/emit_event_from_cpp/napi/src/utils.h
+++ b/emit_event_from_cpp/napi/src/utils.h
@@ -24,7 +24,7 @@ public:
   bool next(T& elem) {
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, [&] (void) { return !qu.empty(); });
-    if (qu.empty()) { // later wake up the lock for destroy, qu can be empty
+    if (qu.empty()) {
       return false;
     }
     elem = qu.front();

--- a/emit_event_from_cpp/napi/src/utils.h
+++ b/emit_event_from_cpp/napi/src/utils.h
@@ -9,7 +9,6 @@ class ThreadSafeQueue {
 private:
   std::queue<T> qu;
   std::mutex m;
-  std::condition_variable cv;
 public:
   bool push(T elem) {
     if (elem == nullptr) {
@@ -17,13 +16,11 @@ public:
     }
     std::unique_lock<std::mutex> lock(m);
     qu.push(elem);
-    cv.notify_one();
     return true;
   }
 
   bool next(T& elem) {
     std::unique_lock<std::mutex> lock(m);
-    cv.wait(lock, [&] (void) { return !qu.empty(); });
     if (qu.empty()) {
       return false;
     }

--- a/emit_event_from_cpp/napi/src/utils.h
+++ b/emit_event_from_cpp/napi/src/utils.h
@@ -1,0 +1,51 @@
+#ifndef __SAFE_QUEUE_H
+#define __SAFE_QUEUE_H
+
+#include <queue>
+#include <mutex>
+
+template<class T>
+class ThreadSafeQueue {
+private:
+  std::queue<T> qu;
+  std::mutex m;
+  std::condition_variable cv;
+public:
+  bool push(T elem) {
+    if (elem == nullptr) {
+      return false;
+    }
+    std::unique_lock<std::mutex> lock(m);
+    qu.push(elem);
+    cv.notify_one();
+    return true;
+  }
+
+  bool next(T& elem) {
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait(lock, [&] (void) { return !qu.empty(); });
+    if (qu.empty()) { // later wake up the lock for destroy, qu can be empty
+      return false;
+    }
+    elem = qu.front();
+    qu.pop();
+    return true;
+  }
+
+  bool empty() {
+    std::unique_lock<std::mutex> lock(m);
+    return qu.empty();
+  }
+};
+
+template <class T>
+class AutoDelete
+{
+  public:
+    AutoDelete (T * p = 0) : ptr_(p) {}
+    ~AutoDelete () throw() { delete ptr_; }
+  private:
+    T *ptr_;
+};
+
+#endif


### PR DESCRIPTION
This PR shows one way to use native threads to generate events for node.

This example is not blocking

Events are queue'd up by the native threads and consumed by nodejs libuv loop.