### PR TITLE
Added async pi estimate example in NAPI

### DIFF
--- a/async_pi_estimate/napi/README.md
+++ b/async_pi_estimate/napi/README.md
@@ -1,0 +1,1 @@
+In this directory run `node-gyp rebuild` and then `node ./addon.js`

--- a/async_pi_estimate/napi/addon.cc
+++ b/async_pi_estimate/napi/addon.cc
@@ -1,0 +1,24 @@
+#include <node_api.h>
+#include <assert.h>
+#include "sync.h"   // NOLINT(build/include)
+#include "async.h"  // NOLINT(build/include)
+
+#define DECLARE_NAPI_METHOD(name, func)                          \
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
+
+// Expose synchronous and asynchronous access to our
+// Estimate() function
+napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
+
+  napi_property_descriptor desc[] = {
+    DECLARE_NAPI_METHOD("calculateSync", CalculateSync),
+    DECLARE_NAPI_METHOD("calculateAsync", CalculateAsync),
+  };
+  status =
+    napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc);
+  assert(status == napi_ok);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/async_pi_estimate/napi/addon.js
+++ b/async_pi_estimate/napi/addon.js
@@ -1,0 +1,44 @@
+var addon = require('bindings')('addon');
+var calculations = process.argv[2] || 100000000;
+
+function printResult(type, pi, ms) {
+  console.log(type, 'method:');
+  console.log('\tπ ≈ ' + pi +
+              ' (' + Math.abs(pi - Math.PI) + ' away from actual)');
+  console.log('\tTook ' + ms + 'ms');
+  console.log();
+}
+
+function runSync() {
+  var start = Date.now();
+  // Estimate() will execute in the current thread,
+  // the next line won't return until it is finished
+  var result = addon.calculateSync(calculations);
+  printResult('Sync', result, Date.now() - start);
+}
+
+function runAsync() {
+  // how many batches should we split the work in to?
+  var batches = process.argv[3] || 16;
+  var ended = 0;
+  var total = 0;
+  var start = Date.now();
+
+  function done (err, result) {
+    total += result;
+
+    // have all the batches finished executing?
+    if (++ended === batches) {
+      printResult('Async', total / batches, Date.now() - start);
+    }
+  }
+
+  // for each batch of work, request an async Estimate() for
+  // a portion of the total number of calculations
+  for (var i = 0; i < batches; i++) {
+    addon.calculateAsync(calculations / batches, done);
+  }
+}
+
+runSync();
+runAsync();

--- a/async_pi_estimate/napi/async.cc
+++ b/async_pi_estimate/napi/async.cc
@@ -1,0 +1,93 @@
+#include "pi_est.h"  // NOLINT(build/include)
+#include "async.h"  // NOLINT(build/include)
+
+typedef struct {
+  napi_ref _callback;
+  napi_async_work _request;
+
+  int points;
+  double estimate;
+
+} async_calculate_data;
+
+// Executed inside the worker-thread.
+// It is not safe to access JS engine data structure
+// here, so everything we need for input and output
+// should go on `async_calculate_data`.
+void doCalculation(napi_env env, void* param) {
+  async_calculate_data* data = static_cast<async_calculate_data*>(param);
+  data->estimate = Estimate(data->points);
+}
+
+// Executed when the async work is complete
+// this function will be run inside the main event loop
+// so it is safe to use JS engine data again
+void doneCalculation(napi_env env, napi_status status, void* param) {
+  async_calculate_data* data = static_cast<async_calculate_data*>(param);
+
+  napi_value callback;
+  status = napi_get_reference_value(env, data->_callback, &callback);
+  assert(status == napi_ok);
+
+  napi_value global;
+  status = napi_get_global(env, &global);
+  assert(status == napi_ok);
+
+  napi_value argv[2];
+  status = napi_get_undefined(env, &argv[0]);
+  status = napi_create_double(env, data->estimate, &argv[1]);
+  assert(status == napi_ok);
+
+  napi_value result;
+  status = napi_call_function(env, global, callback, 2, argv, &result);
+  assert(status == napi_ok);
+}
+
+// Asynchronous access to the `Estimate()` function
+napi_value CalculateAsync(napi_env env, napi_callback_info info) {
+  napi_status status;
+
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  assert(status == napi_ok);
+
+  if (argc < 2) {
+    napi_throw_type_error(env, nullptr, "Wrong number of arguments");
+    return nullptr;
+  }
+
+  napi_valuetype valuetype0;
+  status = napi_typeof(env, args[0], &valuetype0);
+  assert(status == napi_ok);
+
+  napi_valuetype valuetype1;
+  status = napi_typeof(env, args[1], &valuetype1);
+  assert(status == napi_ok);
+
+  if (valuetype0 != napi_number || valuetype1 != napi_function) {
+    napi_throw_type_error(env, nullptr, "Wrong arguments");
+    return nullptr;
+  }
+
+  async_calculate_data* data = (async_calculate_data*)malloc(sizeof(async_calculate_data));
+
+  status = napi_get_value_int32(env, args[0], &data->points);
+  assert(status == napi_ok);
+
+  status = napi_create_reference(env, args[1], 1, &data->_callback);
+  assert(status == napi_ok);
+
+  napi_value resourceName;
+  status = napi_create_string_utf8(env, "asyncPiCalculation", -1, &resourceName);
+  assert(status == napi_ok);
+
+  status = napi_create_async_work(env, 0, resourceName,
+    doCalculation, doneCalculation, data, &data->_request);
+  assert(status == napi_ok);
+
+  status = napi_queue_async_work(env, data->_request);
+  assert(status == napi_ok);
+
+  return nullptr;
+}

--- a/async_pi_estimate/napi/async.cc
+++ b/async_pi_estimate/napi/async.cc
@@ -38,6 +38,8 @@ void doneCalculation(napi_env env, napi_status status, void* param) {
   status = napi_create_double(env, data->estimate, &argv[1]);
   assert(status == napi_ok);
 
+  free(data);
+
   napi_value result;
   status = napi_call_function(env, global, callback, 2, argv, &result);
   assert(status == napi_ok);

--- a/async_pi_estimate/napi/async.cc
+++ b/async_pi_estimate/napi/async.cc
@@ -38,6 +38,8 @@ void doneCalculation(napi_env env, napi_status status, void* param) {
   status = napi_create_double(env, data->estimate, &argv[1]);
   assert(status == napi_ok);
 
+  status = napi_delete_async_work(env, data->_request);
+  assert(status == napi_ok);
   free(data);
 
   napi_value result;

--- a/async_pi_estimate/napi/async.h
+++ b/async_pi_estimate/napi/async.h
@@ -1,0 +1,11 @@
+#ifndef EXAMPLES_ASYNC_PI_ESTIMATE_ASYNC_H_
+#define EXAMPLES_ASYNC_PI_ESTIMATE_ASYNC_H_
+
+#include <node_api.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+napi_value CalculateAsync(napi_env env, napi_callback_info info);
+
+#endif  // EXAMPLES_ASYNC_PI_ESTIMATE_ASYNC_H_

--- a/async_pi_estimate/napi/binding.gyp
+++ b/async_pi_estimate/napi/binding.gyp
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": [
+        "addon.cc",
+        "pi_est.cc",
+        "sync.cc",
+        "async.cc"
+      ]
+    }
+  ]
+}

--- a/async_pi_estimate/napi/package.json
+++ b/async_pi_estimate/napi/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "async_work",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #9",
+  "main": "addon.js",
+  "private": true,
+  "gypfile": true,
+  "dependencies": {
+    "bindings": "*"
+  }
+}

--- a/async_pi_estimate/napi/pi_est.cc
+++ b/async_pi_estimate/napi/pi_est.cc
@@ -1,0 +1,55 @@
+#include <cstdlib>
+#include "pi_est.h"  // NOLINT(build/include)
+
+/*
+Estimate the value of π by using a Monte Carlo method.
+Take `points` samples of random x and y values on a
+[0,1][0,1] plane. Calculating the length of the diagonal
+tells us whether the point lies inside, or outside a
+quarter circle running from 0,1 to 1,0. The ratio of the
+number of points inside to outside gives us an
+approximation of π/4.
+
+See https://en.wikipedia.org/wiki/File:Pi_30K.gif
+for a visualization of how this works.
+*/
+
+inline int randall(unsigned int *p_seed) {
+// windows has thread safe rand()
+#ifdef _WIN32
+  return rand();  // NOLINT(runtime/threadsafe_fn)
+#else
+  return rand_r(p_seed);
+#endif
+}
+
+double Estimate (int points) {
+  int i = points;
+  int inside = 0;
+  unsigned int randseed = 1;
+
+#ifdef _WIN32
+  srand(randseed);
+#endif
+
+  // unique seed for each run, for threaded use
+  unsigned int seed = randall(&randseed);
+
+#ifdef _WIN32
+  srand(seed);
+#endif
+
+  while (i-- > 0) {
+    double x = randall(&seed) / static_cast<double>(RAND_MAX);
+    double y = randall(&seed) / static_cast<double>(RAND_MAX);
+
+    // x & y and now values between 0 and 1
+    // now do a pythagorean diagonal calculation
+    // `1` represents our 1/4 circle
+    if ((x * x) + (y * y) <= 1)
+      inside++;
+  }
+
+  // calculate ratio and multiply by 4 for π
+  return (inside / static_cast<double>(points)) * 4;
+}

--- a/async_pi_estimate/napi/pi_est.h
+++ b/async_pi_estimate/napi/pi_est.h
@@ -1,0 +1,6 @@
+#ifndef EXAMPLES_ASYNC_PI_ESTIMATE_PI_EST_H_
+#define EXAMPLES_ASYNC_PI_ESTIMATE_PI_EST_H_
+
+double Estimate(int points);
+
+#endif  // EXAMPLES_ASYNC_PI_ESTIMATE_PI_EST_H_

--- a/async_pi_estimate/napi/sync.cc
+++ b/async_pi_estimate/napi/sync.cc
@@ -1,0 +1,38 @@
+#include "pi_est.h"  // NOLINT(build/include)
+#include "sync.h"  // NOLINT(build/include)
+
+// Simple synchronous access to the `Estimate()` function
+napi_value CalculateSync(napi_env env, napi_callback_info info) {
+  napi_status status;
+
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  assert(status == napi_ok);
+
+  if (argc < 1) {
+    napi_throw_type_error(env, nullptr, "Wrong number of arguments");
+    return nullptr;
+  }
+
+  napi_valuetype valuetype0;
+  status = napi_typeof(env, args[0], &valuetype0);
+  assert(status == napi_ok);
+
+  if (valuetype0 != napi_number) {
+    napi_throw_type_error(env, nullptr, "Wrong arguments");
+    return nullptr;
+  }
+
+  int points;
+  status = napi_get_value_int32(env, args[0], &points);
+  assert(status == napi_ok);
+
+  double est = Estimate(points);
+
+  napi_value estimate;
+  status = napi_create_double(env, est, &estimate);
+  assert(status == napi_ok);
+
+  return estimate;
+}

--- a/async_pi_estimate/napi/sync.h
+++ b/async_pi_estimate/napi/sync.h
@@ -1,0 +1,9 @@
+#ifndef EXAMPLES_ASYNC_PI_ESTIMATE_SYNC_H_
+#define EXAMPLES_ASYNC_PI_ESTIMATE_SYNC_H_
+
+#include <node_api.h>
+#include <assert.h>
+
+napi_value CalculateSync(napi_env env, napi_callback_info info);
+
+#endif  // EXAMPLES_ASYNC_PI_ESTIMATE_SYNC_H_


### PR DESCRIPTION
Another example for #10. Please, tell me if I have something wrong.
There is benchmarks:
**NAPI**:
```
Sync method:
        π ≈ 3.14156456 (0.000028093589793165563 away from actual)
        Took 4026ms

Async method:
        π ≈ 3.1418483200000007 (0.00025566641020757785 away from actual)
        Took 2013ms
```
**node-addon-api**:
```
Sync method:
        π ≈ 3.14156456 (0.000028093589793165563 away from actual)
        Took 8251ms

Async method:
        π ≈ 3.1418483200000007 (0.00025566641020757785 away from actual)
        Took 4138ms
```
**nan**:
```
Sync method:
        π ≈ 3.14156456 (0.000028093589793165563 away from actual)
        Took 4886ms

Async method:
        π ≈ 3.1418483200000007 (0.00025566641020757785 away from actual)
        Took 2502ms
```
